### PR TITLE
Add build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,22 @@
+use std::env;
+
+const LIBCAPNG_LIB_NAME: &str = "cap-ng";
+const LIBCAPNG_LIB_PATH: &str = "LIBCAPNG_LIB_PATH";
+const LIBCAPNG_LINK_TYPE: &str = "LIBCAPNG_LINK_TYPE";
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed={}", LIBCAPNG_LIB_PATH);
+    println!("cargo:rerun-if-env-changed={}", LIBCAPNG_LINK_TYPE);
+
+    if let Ok(path) = env::var(LIBCAPNG_LIB_PATH) {
+        println!("cargo:rustc-link-search=native={}", path);
+    }
+
+    let link_type = match env::var(LIBCAPNG_LINK_TYPE) {
+            Ok(val) if matches!(val.as_str(), "dylib" | "static") => val,
+            _ => String::from("dylib"),
+    };
+
+    println!("cargo:rustc-link-lib={}={}", link_type, LIBCAPNG_LIB_NAME);
+}


### PR DESCRIPTION
This build script allows capng to be linked statically
to libcap-ng and/or select the library's location.
To set the link type the build script will check the
env. variable LIBCAPNG_LINK_STATIC, if its value is
'1' or 'true' the 'static' link type is selected, in
other case the `dynlib` is selected.

LIBCAPNG_LIB_PATH=<path> will add the <path> directory
to the compiler's library search path (i.e., -L <path>)

Signed-off-by: German Maglione <gmaglione@redhat.com>