### PR TITLE
Find libcap-ng with pkg-config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ license = "Apache-2.0 OR BSD-3-Clause"
 [dependencies]
 bitflags = "1.0"
 libc = "0.2.69"
+
+[build-dependencies]
+pkg-config = "0.3.24"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    pkg_config::probe_library("libcap-ng").unwrap();
+}


### PR DESCRIPTION
This will take care of figuring out the correct linker paths and flags, in a standard and conventional way.

This is an alternative to #2, which doesn't require the user to manually specify the library path.

Closes #2.